### PR TITLE
Added Docker container for RS-FISH

### DIFF
--- a/.github/.workflows/docker-publish.yml
+++ b/.github/.workflows/docker-publish.yml
@@ -1,0 +1,32 @@
+name: dockerhub
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.RS_FISH_USERNAME }}
+          password: ${{ secrets.RS_FISH_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: preibischlab/rs_fish:${{ github.event.release.tag_name }}
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM maven:3.8.4-jdk-8-slim
+
+RUN apt-get -y update
+RUN apt-get -y install git
+
+RUN echo '<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" \n\
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" \n\
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 \n\
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd"> \n\
+  <localRepository>/RS-FISH/.m2/repository</localRepository> \n\
+</settings>' > $MAVEN_HOME/conf/settings.xml
+
+RUN git clone https://github.com/PreibischLab/RS-FISH
+WORKDIR /RS-FISH
+
+RUN sed -i 's|\\\$|\$|g' install
+RUN HOME=/RS-FISH ./install

--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ This currently installs three tools, `rs-fish, rs-fish-anisotropy, csv-overlay`.
 <br />
 <br />
 
+#### 2.2. Installation using Docker container
+
+Alternatively to installing RS-FISH as a command line tool on your operating system, you can also use it directly from our Docker container. To pull the docker container from Dockerhub, run the following command:
+
+```
+docker pull wuennemannflorian/rs_fish:2.3.1
+```
+
+You can then run RS-FISH from the container using the following command:
+
+```
+docker run -v [your_local_input_folder]:/input -v [your_local_output_folder]:/output rs-fish:2.3.1 /RS-FISH/rs-fish [rs_fish_parameter] --image=/input/[your_file.tif] --output=/output/[your_file.csv]
+```
+
+
 ### 3.	Calculating Anisotropy Coefficient<a name="anisotropy">
 </a> 
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,15 @@ This currently installs three tools, `rs-fish, rs-fish-anisotropy, csv-overlay`.
 
 #### 2.2. Installation using Docker container
 
-Alternatively to installing RS-FISH as a command line tool on your operating system, you can also use it directly from our Docker container. To pull the docker container from Dockerhub, run the following command:
+Alternatively to installing RS-FISH as a command line tool on your operating system, you can also use it directly from our Docker container. 
+
+To build the docker container, git pull the repository and then execute the following command:
+
+```
+docker build -t rs_fish:2.3.1 .
+```
+
+To pull the docker container directly from Dockerhub, run the following command:
 
 ```
 docker pull wuennemannflorian/rs_fish:2.3.1


### PR DESCRIPTION
This PR adds the following things:
- Dockerfile for Docker container creation
- Section in the README on how to pull and use the Docker container
- CI for automatically building and pushing Docker container to Dockerhub on published releases