### PR TITLE
Update $VERSION in install to match pom.xml

### DIFF
--- a/install
+++ b/install
@@ -2,7 +2,7 @@
 
 # This script is shamelessly adapted from https://github.com/saalfeldlab/n5-utils, thanks @axtimwalde & co!
 
-VERSION="2.3.1-SNAPSHOT"
+VERSION="2.3.5-SNAPSHOT"
 INSTALL_DIR=${1:-$(pwd)}
 
 echo ""


### PR DESCRIPTION
rs-fish fails with `Error: Could not find or load main class cmd.RadialSymmetry` because the script references
```
Radial_SymmetryLocalization/2.3.1-SNAPSHOT/Radial_SymmetryLocalization-2.3.1-SNAPSHOT.jar
```

while the actual file is at

```
Radial_SymmetryLocalization/2.3.5-SNAPSHOT/Radial_SymmetryLocalization-2.3.5-SNAPSHOT.jar
```

The proposed change updates the `VERSION` env variable, which is used in https://github.com/PreibischLab/RS-FISH/blob/1ebdf32a1603d6bba674bd88ee7e28392d1d0860/install#L39 to specify the .jar location.